### PR TITLE
Add Docker Pipeline plugin

### DIFF
--- a/jcasc/plugins.txt
+++ b/jcasc/plugins.txt
@@ -1,6 +1,7 @@
 workflow-aggregator
 blueocean
 configuration-as-code
+docker-pipeline
 job-dsl
 git-parameter
 github-oauth


### PR DESCRIPTION
With newer Jenkins version, we started getting the following:
`groovy.lang.MissingPropertyException: No such property: docker for class: groovy.lang.Binding`

To fix this, we need to install jenkins docker pipeline plugin