### PR TITLE
Jrobinson/facilitate main branch change

### DIFF
--- a/jcasc/seedJob.groovy
+++ b/jcasc/seedJob.groovy
@@ -63,6 +63,7 @@ def createJobFromGroovy(String folderName, File groovyFile) {
   def arguments = [:]
   arguments['folderName'] = folderName
   arguments['jenkins'] = this
+  arguments['defaultBranch'] = 'master'
   script.invokeMethod("createJob", arguments)
 }
 

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -1,0 +1,3 @@
+def defaultBranch() {
+    def defaultBranch = 'master'
+}

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -1,3 +1,3 @@
 def defaultBranch() {
-    def defaultBranch = 'master'
+    return 'master'
 }


### PR DESCRIPTION
This adds a global variable setting the default branch name. 
This can be used in Jenkinsfile's so that we have a central place to set the default branch. 
For example:
https://github.com/department-of-veterans-affairs/appeals-deployment/blob/jrobinson/facilitate-main-branch-change/jenkins/caseflow-docker-image-creation/job.groovy#L26