### PR TITLE
Do not attempt to display empty messages

### DIFF
--- a/vars/customSlack.groovy
+++ b/vars/customSlack.groovy
@@ -36,7 +36,7 @@ def call(Map stageParams) {
                         |${currentBuild.getAbsoluteUrl()}console `${stageParamsMessage}`""".stripMargin()
     }
     else {
-        message = stageParams.message ? stageParams.message : """${buildResult}
+        message = stageParamsMessage ? stageParamsMessage : """${buildResult}
                   |Job: ${env.JOB_NAME}
                   |Build Numer: ${env.BUILD_NUMBER}
                   |${currentBuild.getAbsoluteUrl()}""".stripMargin()

--- a/vars/customSlack.groovy
+++ b/vars/customSlack.groovy
@@ -11,12 +11,11 @@ def call(Map stageParams) {
     messageType = stageParams.messageType
     jobType = env.JOB_NAME.split('/')[0]
     amiHash = stageParams.amiHash != null ? "Git hash: `${stageParams.amiHash}`" : ''
+    stageParamsMessage = stageParams.message != null ? "\n" + """```${stageParams.message}```"""
     message = ''
 
     if (messageType == "START") {
-        message = """Start Jenkins pipelne job `${env.JOB_NAME}` for `${appName}` to environment `${environment}`.
-                  ```${stageParams.message}```
-        """
+        message = """Start Jenkins pipeline job `${env.JOB_NAME}` for `${appName}` to environment `${environment}`. `${stageParamsMessage}`"""
         if (environment in PROD_ENVS
            && appName in CASEFLOW_APPS
            && jobType in DEPLOY_JOBS) {
@@ -26,8 +25,7 @@ def call(Map stageParams) {
     }
     else if (messageType == "FINISH") {
         message =  """Finished Jenkins pipeline job `${env.JOB_NAME}` for `${appName}` to environment `${environment}`.
-                        |${amiHash}
-                        ```${stageParams.message}```""".stripMargin()
+                        |${amiHash} `${stageParamsMessage}`""".stripMargin()
         if (jobType in DEPLOY_JOBS) {
             message = "*Deployment Successful*\n" + message
         }
@@ -35,8 +33,7 @@ def call(Map stageParams) {
     else if (messageType == "FAILURE") {
         message = """@here Failed Jenkins pipeline for `${env.JOB_NAME}` on application `${appName ?: ''}` to environment `${environment}`!
                         |Reason: `${stageParams.error}`
-                        |${currentBuild.getAbsoluteUrl()}console
-                        ```${stageParams.message}```""".stripMargin()
+                        |${currentBuild.getAbsoluteUrl()}console `${stageParamsMessage}`""".stripMargin()
     }
     else {
         message = stageParams.message ? stageParams.message : """${buildResult}

--- a/vars/customSlack.groovy
+++ b/vars/customSlack.groovy
@@ -11,7 +11,7 @@ def call(Map stageParams) {
     messageType = stageParams.messageType
     jobType = env.JOB_NAME.split('/')[0]
     amiHash = stageParams.amiHash != null ? "Git hash: `${stageParams.amiHash}`" : ''
-    stageParamsMessage = stageParams.message != null ? "\n" + """```${stageParams.message}```"""
+    stageParamsMessage = stageParams.message != null ? "\n" + """```${stageParams.message}```""" : ''
     message = ''
 
     if (messageType == "START") {

--- a/vars/customSlack.groovy
+++ b/vars/customSlack.groovy
@@ -11,11 +11,11 @@ def call(Map stageParams) {
     messageType = stageParams.messageType
     jobType = env.JOB_NAME.split('/')[0]
     amiHash = stageParams.amiHash != null ? "Git hash: `${stageParams.amiHash}`" : ''
-    stageParamsMessage = stageParams.message != null ? "\n" + """```${stageParams.message}```""" : ''
+    stageParamsMessage = stageParams.message != '' ? "\n" + """```${stageParams.message}```""" : ''
     message = ''
 
     if (messageType == "START") {
-        message = """Start Jenkins pipeline job `${env.JOB_NAME}` for `${appName}` to environment `${environment}`. `${stageParamsMessage}`"""
+        message = """Start Jenkins pipeline job `${env.JOB_NAME}` for `${appName}` to environment `${environment}`. ${stageParamsMessage}"""
         if (environment in PROD_ENVS
            && appName in CASEFLOW_APPS
            && jobType in DEPLOY_JOBS) {
@@ -25,7 +25,7 @@ def call(Map stageParams) {
     }
     else if (messageType == "FINISH") {
         message =  """Finished Jenkins pipeline job `${env.JOB_NAME}` for `${appName}` to environment `${environment}`.
-                        |${amiHash} `${stageParamsMessage}`""".stripMargin()
+                        |${amiHash} ${stageParamsMessage}""".stripMargin()
         if (jobType in DEPLOY_JOBS) {
             message = "*Deployment Successful*\n" + message
         }
@@ -33,7 +33,7 @@ def call(Map stageParams) {
     else if (messageType == "FAILURE") {
         message = """@here Failed Jenkins pipeline for `${env.JOB_NAME}` on application `${appName ?: ''}` to environment `${environment}`!
                         |Reason: `${stageParams.error}`
-                        |${currentBuild.getAbsoluteUrl()}console `${stageParamsMessage}`""".stripMargin()
+                        |${currentBuild.getAbsoluteUrl()}console ${stageParamsMessage}""".stripMargin()
     }
     else {
         message = stageParamsMessage ? stageParamsMessage : """${buildResult}


### PR DESCRIPTION
This PR gets rid of the empty lines at the bottom of many Slack messages caused by an empty `stageParams.message` so that we can see more messages at once in the #appeals-deployment Slack channel.

![image](https://user-images.githubusercontent.com/32683958/121534627-6384e880-c9cf-11eb-848b-a38a1c7c13b8.png)
