### PR TITLE
Jrobinson/bugfix modified messages

### DIFF
--- a/vars/customSlack.groovy
+++ b/vars/customSlack.groovy
@@ -36,7 +36,7 @@ def call(Map stageParams) {
                         |${currentBuild.getAbsoluteUrl()}console ${stageParamsMessage}""".stripMargin()
     }
     else {
-        message = stageParamsMessage ? stageParamsMessage : """${buildResult}
+        message = stageParams.message ? stageParams.message : """${buildResult}
                   |Job: ${env.JOB_NAME}
                   |Build Numer: ${env.BUILD_NUMBER}
                   |${currentBuild.getAbsoluteUrl()}""".stripMargin()

--- a/vars/customSlack.groovy
+++ b/vars/customSlack.groovy
@@ -11,7 +11,8 @@ def call(Map stageParams) {
     messageType = stageParams.messageType
     jobType = env.JOB_NAME.split('/')[0]
     amiHash = stageParams.amiHash != null ? "Git hash: `${stageParams.amiHash}`" : ''
-    stageParamsMessage = stageParams.message != '' ? "\n" + """```${stageParams.message}```""" : ''
+    // stageParams.message?.trim() return false for null and empty string
+    stageParamsMessage = stageParams.message?.trim() ? "\n" + """```${stageParams.message}```""" : ''
     message = ''
 
     if (messageType == "START") {


### PR DESCRIPTION
We were getting some messages on #appeals-deployment like:
```
null
```
This was caused by some changes to customSlack. 
Lowell and I had made some change to get rid of blank
\`\`\` \`\`\`
message blocks. 
This will roll back a change to an `else` block the I shouldn't have made.

Also added an additional change to the message check to make sure it returns false for null or an empty string.

Ran a test build with:
**Update Lambdas**
Jenkins
https://jenkins.uat.appeals.va.gov/job/devops/job/update-lambdas/114/
Slack message
https://dsva.slack.com/archives/C7VNGMYUQ/p1624390452329900
**PreProd Bake**
Jenkins
https://jenkins.uat.appeals.va.gov/job/builds/job/preprod/job/certification/844/
Slack
https://dsva.slack.com/archives/C7VNGMYUQ/p1624391551331600