### PR TITLE
Add pipeline-utility-steps to

### DIFF
--- a/jcasc/plugins.txt
+++ b/jcasc/plugins.txt
@@ -10,3 +10,4 @@ ws-cleanup
 credentials
 configuration-as-code-support
 envinject
+pipeline-utility-steps


### PR DESCRIPTION
Add [pipeline utility steps plugins](https://plugins.jenkins.io/pipeline-utility-steps/#documentation). Needed to be able to use the [`ReadJSON` function](https://www.jenkins.io/doc/pipeline/steps/pipeline-utility-steps/#readjson-read-json-from-files-in-the-workspace).

Tested adding the plugin manually to Jenkins.