### PR TITLE
remove readonly permissions for anon users to Jenkins

### DIFF
--- a/jcasc/jenkins.yaml
+++ b/jcasc/jenkins.yaml
@@ -14,8 +14,8 @@ jenkins:
   authorizationStrategy:
     github:
       adminUserNames: "<admins>"
-      allowAnonymousJobStatusPermission: true
-      allowAnonymousReadPermission: true
+      allowAnonymousJobStatusPermission: false
+      allowAnonymousReadPermission: false
       allowCcTrayPermission: false
       allowGithubWebHookPermission: true
       authenticatedUserCreateJobPermission: false


### PR DESCRIPTION
### Description
<!-- below discuss what this PR does-->
These changes remove the read only access to Jenkins. With these changes Anonymous Users will not be able to read Jenkins Job output or access the Jenkins GUI


### Relations
<!-- below relate any/all Slack thread, Sentry item, Github issue, Epic to provide more context -->
- No Jira Issue Yet

### Process
<!-- below add a sublist item detailing the action you took or why none is needed and check off the item when done -->
- [ ] Change is tested - explain how the change was tested and include the exact steps if applicable
- [ ] Documentation is updated
- [ ] Deploy is planned
