### PR TITLE
Jenkins ready-only enabled

### DIFF
--- a/jcasc/jenkins.yaml
+++ b/jcasc/jenkins.yaml
@@ -14,8 +14,8 @@ jenkins:
   authorizationStrategy:
     github:
       adminUserNames: "<admins>"
-      allowAnonymousJobStatusPermission: false
-      allowAnonymousReadPermission: false
+      allowAnonymousJobStatusPermission: true
+      allowAnonymousReadPermission: true
       allowCcTrayPermission: false
       allowGithubWebHookPermission: true
       authenticatedUserCreateJobPermission: false


### PR DESCRIPTION
These changes to line 17 & 18 change Jenkins config when its deployed once a month to allow read-only that was previously disabled.