### PR TITLE
update seed job to disable jobs by default upon creation

### DIFF
--- a/jcasc/jenkins.yaml
+++ b/jcasc/jenkins.yaml
@@ -177,6 +177,7 @@ jobs:
             }
             parameters {
                 stringParam('DEPLOYMENT_DEV_BRANCH', 'aws-vaec-migration', 'appeals-deployment branch')
+                booleanParam('SEED_JOB_DISABLED', 'true', 'Disable/enable the Jenkins jobs created by the seed-job')
             }
             triggers {
                 cron('H H(0-5) * * *')

--- a/jcasc/jenkins.yaml
+++ b/jcasc/jenkins.yaml
@@ -177,7 +177,7 @@ jobs:
             }
             parameters {
                 stringParam('DEPLOYMENT_DEV_BRANCH', 'aws-vaec-migration', 'appeals-deployment branch')
-                booleanParam('SEED_JOB_DISABLED', 'true', 'Disable/enable the Jenkins jobs created by the seed-job')
+                booleanParam('SEED_JOB_DISABLED', true, 'Disable/enable the Jenkins jobs created by the seed-job')                
             }
             triggers {
                 cron('H H(0-5) * * *')

--- a/jcasc/seedJob.groovy
+++ b/jcasc/seedJob.groovy
@@ -65,6 +65,7 @@ def createJobFromGroovy(String folderName, File groovyFile) {
   arguments['folderName'] = folderName
   arguments['jenkins'] = this
   arguments['defaultBranch'] = deploymentBranch
+  arguments['jobDisabled'] = "${SEED_JOB_DISABLED}"
   script.invokeMethod('createJob', arguments)
 }
 


### PR DESCRIPTION
This PR updates the jenkins.yaml and seedJob.groovy to disable the jobs created by the seed job. The files were updated to include a boolean parameter to toggle the disable flag on/off and set the value of that parameter as a variable to be used by the jobdefs files in appeals-terraform. That repo is being updated for this effort. 