### PR TITLE
update slack token to use VAEC

### DIFF
--- a/jcasc/jenkins.yaml
+++ b/jcasc/jenkins.yaml
@@ -142,7 +142,7 @@ unclassified:
   slackNotifier:
     teamDomain: "dsva"
     baseUrl: ""
-    tokenCredentialId: "SLACK_TOKEN"
+    tokenCredentialId: "VAEC_SLACK_TOKEN"
     botUser: true
     room: "#appeals-alerts-vaec"
     #room: "#appeals-deployment"

--- a/vars/customSlack.groovy
+++ b/vars/customSlack.groovy
@@ -42,7 +42,7 @@ def call(Map stageParams) {
     }
 
   success_channel = stageParams.channel
-  failure_channel = stageParams.failure_channel ? stageParams.failure_channel : 'appeals-devops-alerts'
+  failure_channel = stageParams.failure_channel ? stageParams.failure_channel : 'appeals-alerts-vaec'
 
   try {
     if ( buildResult == 'SUCCESS' ) {


### PR DESCRIPTION
update the Slack configuration for Jenkins to use the VAEC_SLACK_TOKEN for authentication