### PR TITLE
removing authentication issues from github plugin

### DIFF
--- a/jcasc/jenkins.yaml
+++ b/jcasc/jenkins.yaml
@@ -19,9 +19,9 @@ jenkins:
       allowCcTrayPermission: false
       allowGithubWebHookPermission: true
       authenticatedUserCreateJobPermission: false
-      authenticatedUserReadPermission: true
+      authenticatedUserReadPermission: false
       organizationNames: "<github_org_name>"
-      useRepositoryPermissions: true
+      useRepositoryPermissions: false
   disableRememberMe: true
   mode: NORMAL
   primaryView:


### PR DESCRIPTION
This PR removes the 'true' statement for allowing ANY users associated w/ DSVA Github the ability to log into our jenkins box.