### PR TITLE
changing default branch back to master

### DIFF
--- a/jcasc/jenkins.yaml
+++ b/jcasc/jenkins.yaml
@@ -152,7 +152,7 @@ unclassified:
     libraries:
       - name: "appeals-devops-jenkins"
         #set to VAEC branch for initial Jenkins deployment
-        defaultVersion: "aws-vaec-migration"
+        defaultVersion: "master"
         implicit: true
         retriever:
           modernSCM:
@@ -178,7 +178,7 @@ jobs:
                 dsl(['seedJob.groovy'])
             }
             parameters {
-                stringParam('DEPLOYMENT_DEV_BRANCH', 'aws-vaec-migration', 'appeals-deployment branch')
+                stringParam('DEPLOYMENT_DEV_BRANCH', 'master', 'appeals-deployment branch')
                 booleanParam('SEED_JOB_DISABLED', true, 'Disable/enable the Jenkins jobs created by the seed-job')                
             }
             triggers {


### PR DESCRIPTION
For Jenkins rebuild after the prod cutover we need to change the default branch back to master.  This PR updates the jenkins.yml for those fixes.