### PR TITLE
update failure_channel variable reference

### DIFF
--- a/vars/customSlack.groovy
+++ b/vars/customSlack.groovy
@@ -42,7 +42,7 @@ def call(Map stageParams) {
     }
 
   success_channel = stageParams.channel
-  failure_channel = stageParams.failure_channel ? stageParams.failure_channel : 'appeals-alerts-vaec'
+  failure_channel = stageParams.failure_channel ? stageParams.failure_channel : stageParams.channel
 
   try {
     if ( buildResult == 'SUCCESS' ) {


### PR DESCRIPTION
This PR updates the failure_channel reference to use the slack_channel parameter from the deploy-caseflow-demo Jenkins job when there is a failure. This has been tested by updating the branch for the Global Pipeline Library to this working branch and then requesting a demo deployment in Slack with a bad/incorrect caseflow branch name. The Jenkins job failed and the notification was sent to the appeals-demo Slack channel as expected. 

The Jira story associated with this PR is https://jira.devops.va.gov/browse/APPEALS-42818 and has screenshots from the test.