### PR TITLE
remove jobDisabled parameter and variable reference from the seedJob

### DIFF
--- a/jcasc/jenkins.yaml
+++ b/jcasc/jenkins.yaml
@@ -178,8 +178,7 @@ jobs:
                 dsl(['seedJob.groovy'])
             }
             parameters {
-                stringParam('DEPLOYMENT_DEV_BRANCH', 'master', 'appeals-deployment branch')
-                booleanParam('SEED_JOB_DISABLED', true, 'Disable/enable the Jenkins jobs created by the seed-job')                
+                stringParam('DEPLOYMENT_DEV_BRANCH', 'master', 'appeals-deployment branch')                
             }
             triggers {
                 cron('H H(0-5) * * *')

--- a/jcasc/seedJob.groovy
+++ b/jcasc/seedJob.groovy
@@ -64,8 +64,7 @@ def createJobFromGroovy(String folderName, File groovyFile) {
   def arguments = [:]
   arguments['folderName'] = folderName
   arguments['jenkins'] = this
-  arguments['defaultBranch'] = "${DEPLOYMENT_DEV_BRANCH}" 
-  arguments['jobDisabled'] = "${SEED_JOB_DISABLED}"
+  arguments['defaultBranch'] = "${DEPLOYMENT_DEV_BRANCH}"
   arguments['accountENV'] = "$ACCOUNT_ENV"
   script.invokeMethod('createJob', arguments)
 }


### PR DESCRIPTION
This PR removes the jobDisabled parameter and variable from the seedJob. This variable never worked as intended and is not needed.